### PR TITLE
Avoid troublesome `esModuleInterop`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
 		],
 		"module": "commonjs",
 		"moduleResolution": "node",
-		"esModuleInterop": true,
 		"declaration": true,
 		"pretty": true,
 		"newLine": "lf",


### PR DESCRIPTION
I opened this draft PR to test this but apparently Travis doesn't run anymore. Thanks, Obama.
